### PR TITLE
docs: fix link to project page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1073,7 +1073,7 @@ table {
   <h1 class="title"><span class="name">hjson</span> module</h1>
   <p>Hjson, the Human JSON. A configuration file format that caters to
 humans and helps reduce the errors they make.</p>
-<p>For details and syntax see <a href="http://hjson.org">http://hjson.org</a>.</p>
+<p>For details and syntax see <a href="https://hjson.github.io/">https://hjson.github.io/</a>.</p>
 <p>Decoding Hjson::</p>
 <pre><code>&gt;&gt;&gt; import hjson
 &gt;&gt;&gt; text = "{\n  foo: a\n  bar: 1\n}"
@@ -1107,7 +1107,7 @@ Other formats are -c for compact or -j for formatted JSON.
     <pre><code>r"""Hjson, the Human JSON. A configuration file format that caters to
 humans and helps reduce the errors they make.
 
-For details and syntax see <http://hjson.org>.
+For details and syntax see <https://hjson.github.io/>.
 
 Decoding Hjson::
 


### PR DESCRIPTION
Fixes the link on the GitHub pages documentation. The link was changed for other files in 20a809beedfc05255c3d5c79dee6f4d1b7ea46f1 but it was not changed in `docs/index.html`